### PR TITLE
Invalidate the viewport and svg when a new element is added

### DIFF
--- a/lib/SVG/Timeline.pm
+++ b/lib/SVG/Timeline.pm
@@ -88,6 +88,9 @@ around 'add_event' => sub {
   my $orig = shift;
   my $self = shift;
 
+  $self->_clear_viewbox;
+  $self->_clear_svg;
+
   my $index = $self->count_events + 1;
   $_[0]->{index} = $index;
 
@@ -136,6 +139,7 @@ has viewbox => (
   is         => 'ro',
   isa        => 'Str',
   lazy_build => 1,
+  clearer    => '_clear_viewbox',
 );
 
 sub _build_viewbox {
@@ -158,6 +162,7 @@ has svg => (
   is         => 'ro',
   isa        => 'SVG',
   lazy_build => 1,
+  clearer    => '_clear_svg',
   handles    => [qw[xmlify line text rect cdata]],
 );
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -16,6 +16,17 @@ $tl->add_event({
 is($tl->count_events, 1, 'Correct number of events');
 is($tl->events->[0]->index, 1, 'Correct index for event');
 isa_ok($tl->svg, 'SVG');
+my $vb1 = $tl->svg->getChildren->[0]{viewBox};
+
+$tl->add_event({
+  start => 1991,
+  end   => localtime->year,
+  text  => 'Python',
+});
+is($tl->count_events, 2, 'Correct number of events');
+
+my $vb2 = $tl->svg->getChildren->[0]{viewBox};
+isnt($vb1, $vb2, 'Viewbox changed');
 
 my $diag = $tl->draw;
 


### PR DESCRIPTION
Before the invalidation, adding an element after the svg has already
been constructed results in SVG with elements possibly outside the
viewport.